### PR TITLE
Added setup hook that creates admin user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 DESTDIR?=
 PREFIX?=/usr
 BINDIR=$(PREFIX)/bin
-LIBDIR=$(PREFIX)/lib/susemanager/bin
+LIBDIR=$(PREFIX)/lib/susemanager
 DEST_BINDIR=$(DESTDIR)$(BINDIR)
 DEST_LIBDIR=$(DESTDIR)$(LIBDIR)
 
@@ -10,13 +10,15 @@ version=$(shell rpm -q --specfile --qf '%{VERSION}\n' susemanager-cloud-setup.sp
 
 install:
 	mkdir -p $(DEST_BINDIR)
-	mkdir -p $(DEST_LIBDIR)
-	install -m 755 susemanager-cloud-storage-setup-functions.sh $(DEST_LIBDIR)
+	mkdir -p $(DEST_LIBDIR)/bin
+	mkdir -p $(DEST_LIBDIR)/hooks
+	install -m 755 susemanager-cloud-setup-functions.sh $(DEST_LIBDIR)/bin
+	install -m 755 suma_completehook.sh $(DEST_LIBDIR)/hooks
 	install -m 755 suma-storage-server $(DEST_BINDIR)
 	install -m 755 suma-storage-proxy $(DEST_BINDIR)
 
 tarball:
-	mkdir susemanager-cloud-storage-setup-$(version)
-	cp LICENSE Makefile susemanager-cloud-storage-setup-functions.sh suma-storage-server suma-storage-proxy susemanager-cloud-setup-$(version)
-	tar czf susemanager-cloud-storage-setup-$(version).tar.gz susemanager-cloud-storage-setup-$(version)
-	rm -r susemanager-cloud-storage-setup-$(version)
+	mkdir susemanager-cloud-setup-$(version)
+	cp LICENSE Makefile suma_completehook.sh susemanager-cloud-setup-functions.sh suma-storage-server suma-storage-proxy susemanager-cloud-setup-$(version)
+	tar czf susemanager-cloud-setup-$(version).tar.gz susemanager-cloud-setup-$(version)
+	rm -r susemanager-cloud-setup-$(version)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # susemanager-cloud-setup
 
-This is a simple script to set up a storage device for use with SUSE Manager.
-There are two versions, the server and the proxy version. Both versions
-partition and fromat the given block device and mount it to the system, The
-server version is for SUSE Manager Server and moves the package repository and
-the data base to the given device. The proxy version is for SUSE Manager Proxy
-and moves the squid cache to the given device.
+This project contains a few scripts to help set up SUSE Manager in the public
+cloud. It is not a replacement for the YaST2 `susemanager_setup` module,
+but it contains a hook script for it that creates a user account for the
+administrator automatically.
+
+This repository also contains scripts to set up a storage device for use with
+SUSE Manager. There are two versions, the server and the proxy version. Both
+versions partition and fromat the given block device and mount it to the
+system, The server version is for SUSE Manager Server and moves the package
+repository and the data base to the given device. The proxy version is for SUSE
+Manager Proxy and moves the squid cache to the given device.
 
 ## Installation
 ```
@@ -18,6 +23,4 @@ make install
 suma-storage-[server|proxy] block_device
 ```
 
-### Notes
-
-`susemanager-cloud-setup` does not add the storage device to `/etc/fstab`.
+The hook script for YaST2 is executed automatically.

--- a/suma_completehook.sh
+++ b/suma_completehook.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# Copyright (c) 2019 SUSE Linux GmbH
+#
+# This file is part of susemanager-cloud-setup.
+#
+# susemanager-cloud-setup is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# susemanager-cloud-setup is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+
+AZUREMETADATA=$(type -p azuremetadata)
+EC2METADATA=$(type -p ec2metadata)
+GCEMETADATA=$(type -p gcemetadata)
+LOGFILE=/var/log/susemanager_firstuser.log
+
+# init log
+touch $LOGFILE
+chmod 600 $LOGFILE
+exec &> >(tee -a $LOGFILE)
+
+echo "$0 started `date`"
+
+if [[ -n $AZUREMETADATA ]]; then
+    public_hostname=$($AZUREMETADATA --cloud-service --bare)
+    admin_pass=$($AZUREMETADATA --instance-name --bare)-suma
+fi
+if [[ -n $EC2METADATA && -z $public_hostname ]]; then
+    public_hostname=$($EC2METADATA --public-hostname)
+    admin_pass=$($EC2METADATA --instance-id)
+fi
+if [[ -n $GCEMETADATA && -z $public_hostname ]]; then
+    public_hostname=`host $($GCEMETADATA --query instance --external-ip) | sed -r -e 's/(.* )(.*)./\2/'`
+    admin_pass=$($GCEMETADATA --query instance --id)
+fi
+
+# fallbacks
+if [[ -z $public_hostname ]]; then
+    public_hostname=$(hostname -f)
+    echo "Warning: Could not detect cloud framework or public hostname. Using '$public_hostname'."
+fi
+if [[ -z $admin_pass ]]; then
+    admin_pass=$(dd if=/dev/random bs=1 |tr -cd '[a-zA-Z0-9!@#$%^&]' |head -c 12)
+    echo "Warning: Could not detect cloud framework. Using random admin password."
+fi
+
+if [[ -f /etc/motd.finished ]]; then
+    mv /etc/motd.finished /etc/motd
+
+    # Update motd message now that the service is running
+    echo "You can access SUSE Manager via https://$public_hostname" >> /etc/motd
+fi
+
+function listening {
+    local check=0
+    while true; do
+        # check whether we can connect to https
+        exec 2>&1 6<>/dev/tcp/127.0.0.1/443
+        local port_open=$?
+        exec 6>&- # close output connection
+        exec 6<&- # close input connection
+
+        # wait for a bit for apache to be available
+        if [[ $port_open -ne 0 && $check -lt 15 ]]; then
+            check=$((check + 1))
+            sleep 2
+            continue
+        fi
+
+        return $port_open
+    done
+}
+
+if listening; then
+    echo "Creating SUSE Manager Admin user (password '$admin_pass')"
+    curl -s -S -X POST \
+        -k "https://localhost/rhn/newlogin/CreateFirstUser.do" \
+        -d "submitted=true" \
+        -d "login=admin" \
+        -d "desiredpassword=$admin_pass" \
+        -d "desiredpasswordConfirm=$admin_pass" \
+        -d "firstNames=Administrator" \
+        -d "lastName=McAdmin" \
+        -d "email=root@localhost" \
+        -d "prefix=Mr." \
+        -d "orgName=Organisation"
+    ret=$?
+else
+    echo "Warning: http server not running, cannot create admin user."
+    ret=1
+fi
+
+echo "$0 done `date`"
+
+exit $ret

--- a/susemanager-cloud-setup.spec
+++ b/susemanager-cloud-setup.spec
@@ -1,5 +1,5 @@
 #
-# spec file for package susemanager-cloud-setup-storage
+# spec file for package susemanager-cloud-setup
 #
 # Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
 #
@@ -16,24 +16,24 @@
 #
 
 
-Name:           susemanager-cloud-storage-setup
+Name:           susemanager-cloud-setup
 Version:        1.0
 Release:        0
-Summary:        Storage setup script for SUSE Manager
+Summary:        Cloud specific setup scripts for SUSE Manager
 License:        GPL-3.0-or-later
 Group:          System/Management
 Url:            https://github.com/SUSE-Enceladus/susemanager-cloud-setup
-Source:         susemanager-cloud-storage-setup-%{version}.tar.gz
+Source:         susemanager-cloud-setup-%{version}.tar.gz
 
 %description
-A script that sets up external storage for SUSE Manager.
+Scripts that help setting up SUSE Manager in the cloud.
 
 %package server
-Summary:        Storage setup script for SUSE Manager Server
+Summary:        Cloud specific setup scripts for SUSE Manager
 Conflicts:      %{name}-proxy
 
 %description server
-A script that sets up external storage for SUSE Manager Server.
+Scripts that help setting up SUSE Manager Server in the cloud.
 
 %package proxy
 Summary:        Storage setup script for SUSE Manager Proxy
@@ -50,13 +50,13 @@ A script that sets up external storage for SUSE Manager Proxy.
 %install
 make install DESTDIR=%{buildroot} PREFIX=%{_usr}
 
-%post -n susemanager-cloud-storage-setup-server
+%post -n susemanager-cloud-setup-server
 ln -sf suma-storage-server %{_usr}/bin/suma-storage
 
-%post -n susemanager-cloud-storage-setup-proxy
+%post -n susemanager-cloud-setup-proxy
 ln -sf suma-storage-proxy %{_usr}/bin/suma-storage
 
-%files -n susemanager-cloud-storage-setup-server
+%files -n susemanager-cloud-setup-server
 %attr(755,root,root) %{_usr}/bin/suma-storage-server
 %attr(755,root,root) %{_usr}/lib/susemanager
 %ghost %{_usr}/bin/suma-storage


### PR DESCRIPTION
Added hook script for yast2 susemanager_setup that handles creation
of the admin user account.
Renamed package back into susemanager-cloud-setup.
Updated README to include suma_completehook.sh and added explanation
that this is not a full setup tool.