### PR TITLE
suma_completehook: do not print admin password

### DIFF
--- a/suma_completehook.sh
+++ b/suma_completehook.sh
@@ -79,7 +79,8 @@ function listening {
 }
 
 if listening; then
-    echo "Creating SUSE Manager Admin user (password '$admin_pass')"
+    echo "Creating SUSE Manager Admin user"
+    echo "Admin password: '$admin_pass')" >>$LOGFILE
     curl -s -S -X POST \
         -k "https://localhost/rhn/newlogin/CreateFirstUser.do" \
         -d "submitted=true" \
@@ -92,6 +93,7 @@ if listening; then
         -d "prefix=Mr." \
         -d "orgName=Organisation"
     ret=$?
+    echo "NOTE: Admin password has been logged to ${LOGFILE}."
 else
     echo "Warning: http server not running, cannot create admin user."
     ret=1

--- a/susemanager-cloud-setup.spec
+++ b/susemanager-cloud-setup.spec
@@ -17,7 +17,7 @@
 
 
 Name:           susemanager-cloud-setup
-Version:        1.0
+Version:        1.1
 Release:        0
 Summary:        Cloud specific setup scripts for SUSE Manager
 License:        GPL-3.0-or-later


### PR DESCRIPTION
Do not print admin password, but only log it to susemanager_firstuser.log, as
stdout is also logged by YaST to a world-readable file.