### PR TITLE
suma-storage: handle /var/spacewalk correctly (bsc#1172838)

### DIFF
--- a/suma-storage-server
+++ b/suma-storage-server
@@ -101,7 +101,7 @@ info "Syncing SUSE Manager Server directories to storage disk(s)"
 move_storage /var/lib/spacewalk $storage_location
 move_storage /var/lib/pgsql $database_location
 move_storage /var/cache/rhn $storage_location
-if [ -d /var/spacewalk/packages ]; then
+if [ -d /var/spacewalk ]; then
     # copy package storage
     move_storage /var/spacewalk ${storage_location}/spacewalk
 else


### PR DESCRIPTION
Make sure /var/spacewalk is moved if it exists even if it does not contain packages yet (fixes issue on Manager 4.1; bsc#1172838).